### PR TITLE
Add Neatline 3 SPA as git submodule, render at neatline route

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "asset/neatline"]
+	path = asset/neatline
+	url = https://6f2d0fb54eefa9e9affbb944c4697434abc85805:x-oauth-basic@github.com/performant-software/neatline-3.git
+  branch = aks/public-view

--- a/Module.php
+++ b/Module.php
@@ -25,7 +25,8 @@ class Module extends AbstractModule
         $acl = $this->getServiceLocator()->get('Omeka\Acl');
         $acl->allow(
             null,
-            ['Neatline\Api\Adapter\ExhibitAdapter']
+            ['Neatline\Controller\Index',
+             'Neatline\Api\Adapter\ExhibitAdapter']
         );
         $acl->allow(
             Acl::ROLE_GLOBAL_ADMIN,

--- a/asset/js/editor.js
+++ b/asset/js/editor.js
@@ -1,9 +1,0 @@
-(function($) {
-
-    $(document).ready( function() {
-
-        console.log("editor!");
-
-    });
-    
-});

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -4,6 +4,7 @@ return [
     'controllers' => [
         'factories' => [
             'Neatline\Controller\Admin\Exhibits' => 'Neatline\Service\Controller\ExhibitsControllerFactory',
+            'Neatline\Controller\Index' => 'Neatline\Service\Controller\IndexControllerFactory',
         ],
     ],
     'api_adapters' => [
@@ -44,6 +45,18 @@ return [
     ],
     'router' => [
         'routes' => [
+            'neatline' => [
+                'type' => 'Literal',
+                'options' => [
+                    'route' => '/neatline',
+                    'defaults' => [
+                        '__NAMESPACE__' => 'Neatline\Controller',
+                        'controller' => 'index',
+                        'action' => 'index',
+                    ],
+                ],
+                'may_terminate' => true,
+            ],
             'admin' => [
                 'child_routes' => [
                     'site' => [

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Neatline\Controller;
+
+use Zend\View\Model\ViewModel;
+use Zend\Mvc\Controller\AbstractActionController;
+
+class IndexController extends AbstractActionController
+{
+    public function indexAction()
+    {
+        $view = new ViewModel();
+        $asset_manifest = file_get_contents('modules/Neatline/asset/neatline/build/asset-manifest.json');
+        $view->asset_manifest = json_decode($asset_manifest, true);
+        return $view;
+    }
+}

--- a/src/Service/Controller/IndexControllerFactory.php
+++ b/src/Service/Controller/IndexControllerFactory.php
@@ -1,0 +1,16 @@
+<?php
+namespace Neatline\Service\Controller;
+
+use Neatline\Controller\IndexController;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+
+class IndexControllerFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $serviceLocator, $requestedName, array $options = null)
+    {
+        $config = $serviceLocator->get('Config');
+        $indexController = new IndexController($config);
+        return $indexController;
+    }
+}

--- a/view/neatline/index/index.phtml
+++ b/view/neatline/index/index.phtml
@@ -1,0 +1,9 @@
+<?php
+$this->headLink()->appendStylesheet($this->assetUrl('neatline/build/'. $this->asset_manifest['main.css'], 'Neatline'));
+?>
+<h3>Welcome to Neatline</h3>
+<div id="root"></div>
+<?php
+echo $this->inlineScript()
+    ->prependFile($this->assetUrl('neatline/build/' . $this->asset_manifest['main.js'], 'Neatline'));
+?>


### PR DESCRIPTION
### What does this PR do?
- includes the Neatline 3 React frontend application as a git submodule in the asset directory
- adds a base /neatline route and an index controller + view to provide a container for the frontend application
- uses the React-generated asset-manifest.json file to include properly cache-proofed frontend script and CSS in the view

### What issues does it address?
- closes #1 
- closes #8 

### How to test:
- Check that the frontend application displays at https://neatline-3-staging.herokuapp.com/neatline (see https://github.com/performant-software/neatline-3/pull/16)
- Verify that the API endpoint for Neatline exhibits shows a (non-error) JSON response: https://neatline-3-staging.herokuapp.com/api/neatline_exhibits
