### PR TITLE
add custom GeometryCollection Doctrine type for coverage storage

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -25,7 +25,8 @@ class Module extends AbstractModule
     {
         parent::onBootstrap($event);
 
-        Type::addType('point', 'CrEOF\Spatial\DBAL\Types\Geometry\PointType');
+        class_alias('Neatline\PHP\Types\Geometry\GeometryCollection', 'CrEOF\Spatial\PHP\Types\Geometry\GeometryCollection');
+        Type::addType('geometry_collection', 'Neatline\DBAL\Types\Geometry\GeometryCollectionType');
 
         $acl = $this->getServiceLocator()->get('Omeka\Acl');
         $acl->allow(

--- a/src/Api/Adapter/RecordAdapter.php
+++ b/src/Api/Adapter/RecordAdapter.php
@@ -8,7 +8,7 @@ use Omeka\Api\Request;
 use Omeka\Entity\EntityInterface;
 use Omeka\Stdlib\ErrorStore;
 use Omeka\Api\Adapter\SiteSlugTrait;
-use CrEOF\Spatial\PHP\Types\Geometry\Point;
+use Neatline\PHP\Types\Geometry\GeometryCollection;
 
 class RecordAdapter extends AbstractEntityAdapter
 {
@@ -60,13 +60,14 @@ class RecordAdapter extends AbstractEntityAdapter
         $coverage = $entity->getCoverage();
         if (isset($data['o:coverage'])) {
             $is_coverage = true;
-            if (isset($data['o:coverage']['coordinates'])) {
-                $coverage = new Point($data['o:coverage']['coordinates'][0],
-                                      $data['o:coverage']['coordinates'][1]);
+            if (isset($data['o:coverage']['features'])) {
+                // $coverage = new Point($data['o:coverage']['coordinates'][0],
+                //                       $data['o:coverage']['coordinates'][1]);
+                $coverage = new GeometryCollection($data['o:coverage']['features']);
             }
         }
         if ($coverage === null) {
-            $coverage = new Point(0, 0);
+            $coverage = new GeometryCollection(array());
         }
         $entity->setCoverage($coverage);
 

--- a/src/DBAL/Types/Geometry/GeometryCollectionType.php
+++ b/src/DBAL/Types/Geometry/GeometryCollectionType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Neatline\DBAL\Types\Geometry;
+
+use CrEOF\Spatial\DBAL\Types\GeometryType;
+
+/**
+ * Doctrine GEOMETRYCOLLECTION type
+ */
+class GeometryCollectionType extends GeometryType
+{
+
+}

--- a/src/Entity/NeatlineRecord.php
+++ b/src/Entity/NeatlineRecord.php
@@ -5,7 +5,7 @@ use DateTime;
 use Omeka\Entity\AbstractEntity;
 use Omeka\Entity\User;
 use Neatline\Entity\NeatlineExhibit;
-use CrEOF\Spatial\PHP\Types\Geometry\Point;
+use Neatline\PHP\Types\Geometry\GeometryCollection;
 
 /**
  * @package     omeka
@@ -86,7 +86,7 @@ class NeatlineRecord extends AbstractEntity
     protected $body;
 
     /**
-     * @Column(type="point")
+     * @Column(type="geometry_collection")
      */
     protected $coverage;
 
@@ -326,7 +326,7 @@ class NeatlineRecord extends AbstractEntity
     	return $this->body;
     }
 
-    public function setCoverage(Point $coverage)
+    public function setCoverage(GeometryCollection $coverage)
     {
     	$this->coverage = $coverage;
     }

--- a/src/PHP/Types/Geometry/GeometryCollection.php
+++ b/src/PHP/Types/Geometry/GeometryCollection.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Neatline\PHP\Types\Geometry;
+
+use CrEOF\Spatial\PHP\Types\AbstractGeometry;
+use CrEOF\Spatial\PHP\Types\Geometry\LineString;
+use CrEOF\Spatial\PHP\Types\Geometry\MultiLineString;
+use CrEOF\Spatial\PHP\Types\Geometry\MultiPoint;
+use CrEOF\Spatial\PHP\Types\Geometry\MultiPolygon;
+use CrEOF\Spatial\PHP\Types\Geometry\Point;
+use CrEOF\Spatial\PHP\Types\Geometry\Polygon;
+use CrEOF\Spatial\Exception\InvalidValueException;
+
+use Exception;
+
+class GeometryCollection extends AbstractGeometry
+{
+    /**
+     * @var AbstractGeometry[] $geometries
+     */
+    protected $geometries = array();
+
+    /**
+     * @param AbstractGeometry[]|array[]
+     * @param null|int                     $srid
+     */
+    public function __construct(array $geometries, $srid = null)
+    {
+        $this->setGeometries($geometries)
+            ->setSrid($srid);
+    }
+
+    /**
+     * @param AbstractGeometry
+     *
+     * @return self
+     */
+    public function addGeometry($geometry)
+    {
+        $this->geometries[] = $this->validateGeometryValue($geometry);
+
+        return $this;
+    }
+
+    /**
+     * @return AbstractGeometry[]
+     */
+    public function getGeometries()
+    {
+        $geometries = array();
+
+        for ($i = 0; $i < count($this->geometries); $i++) {
+            $geometries[] = $this->getGeometry($i);
+        }
+
+        return $geometries;
+    }
+
+    /**
+     * @param int $index
+     *
+     * @return AbstractGeometry
+     */
+    public function getGeometry($index)
+    {
+        if (-1 == $index) {
+            $index = count($this->geometries) - 1;
+        }
+
+        $geometryClass = get_class($this->geometries[$index]);
+
+        return new $geometryClass($this->geometries[$index], $this->srid);
+    }
+
+    /**
+     * @param AbstractGeometry[]|array[] $geometries
+     *
+     * @return self
+     */
+    public function setGeometries(array $geometries)
+    {
+        $this->geometries = $this->validateGeometryCollectionValue($geometries);
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return self::GEOMETRYCOLLECTION;
+    }
+
+    /**
+     * @return AbstractGeometry[]
+     */
+    public function toArray()
+    {
+        return $this->geometries;
+    }
+
+    /**
+     * @param AbstractGeometry[]|array[] $geometries
+     *
+     * @return AbstractGeometry[]
+     */
+    protected function validateGeometryCollectionValue(array $geometries)
+    {
+        foreach ($geometries as &$geometry) {
+            $geometry = $this->validateGeometryValue($geometry);
+        }
+
+        return $geometries;
+    }
+
+    /**
+     * @param array[]|AbstractGeometry $feature
+     *
+     * @return AbstractGeometry[]
+     */
+    protected function validateGeometryValue($feature)
+    {
+        if ($feature instanceof AbstractGeometry) return $feature;
+
+        $type = '(No type)';
+        $coordinates = array();
+        if (array_key_exists('geometry', $feature)) {
+            $geometry = $feature['geometry'];
+            $type = $geometry['type'];
+            $coordinates = $geometry['coordinates'];
+        }
+        else {
+            $type = $feature['type'];
+            $coordinates = $feature['value'];
+        }
+
+        switch ($type) {
+            case 'POINT':
+            case self::POINT:
+                return new Point($coordinates);
+                break;
+            case 'LINESTRING':
+            case self::LINESTRING:
+                return new LineString($coordinates);
+                break;
+            case 'POLYGON':
+            case self::POLYGON:
+                return new Polygon($coordinates);
+                break;
+            case 'MULTIPOINT':
+            case self::MULTIPOINT:
+                return new MultiPoint($coordinates);
+                break;
+            case 'MULTILINESTRING':
+            case self::MULTILINESTRING:
+                return new MultiLineString($coordinates);
+                break;
+            case 'MULTIPOLYGON':
+            case self::MULTIPOLYGON:
+                return new MultiPolygon($coordinates);
+                break;
+            default:
+                throw new InvalidValueException(sprintf('Invalid geometry type "%s"', $type));
+        }
+    }
+
+    /**
+     * @param AbstractGeometry[] $geometries
+     *
+     * @return string
+     */
+    protected function toStringGeometryCollection(array $geometries)
+    {
+        $strings = array();
+
+        foreach ($geometries as $geometry) {
+            $strings[] = sprintf('%s(%s)', strtoupper($geometry->getType()), $geometry);
+        }
+
+        return implode(',', $strings);
+    }
+
+    /**
+     * @return string
+     */
+    public function toJson()
+    {
+        $json['type'] = 'FeatureCollection';
+        $features = array();
+        foreach ($this->geometries as $geometry) {
+            $feature['type'] = 'Feature';
+            $geo['type'] = $geometry->getType();
+            $geo['coordinates'] = $geometry->toArray();
+            $feature['geometry'] = $geo;
+            $features[] = $feature;
+        }
+        $json['features'] = $features;
+        return json_encode($json);
+    }
+
+}


### PR DESCRIPTION
### What does this PR do?
- Adds classes for a GeometryCollection type extending the doctrine2-spatial library in order to support storage of geoJSON FeatureCollection objects
- Updates the coverage field of the Neatline Record resource type to use feature collections rather than single points

### What issues does it address?
- Closes #13 

### How to test:
- At https://neatline-3-staging.herokuapp.com/s/public-site/neatline, click "Public View" under the first exhibit in the table ("My Demo Exhibit").
- Alongside records represented by single points, there should be a record that displays a group of points, lines, and polygons (a feature collection) as its map element. Clicking on any of these grouped shapes should bring up the same record in the info panel ("Brick Lane"). 
- The group of shapes should behave for the purposes of interaction like a single point: e.g. if you click on the rectangle to bring up the info panel for the record, clicking on its larger polygon sibling should close the info panel (the preview mode panel will continue to show the record's title while your cursor is over the shape).
- One of the grouped shapes is a line, which currently displays strangely since the same fill styling is applied to it as the other shapes, causing a non-bordered edge that changes depending on zoom. This will be addressed separately in the front end.