### PR TITLE
Interfacing with frontend

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "asset/neatline"]
 	path = asset/neatline
 	url = https://github.com/performant-software/neatline-3.git
-  branch = aks/editor
+  branch = aks/record-editor

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -60,24 +60,15 @@ return [
     ],
     'router' => [
         'routes' => [
-            'neatline' => [
-                'type' => 'Literal',
-                'options' => [
-                    'route' => '/neatline',
-                    'defaults' => [
-                        '__NAMESPACE__' => 'Neatline\Controller',
-                        'controller' => 'index',
-                        'action' => 'index',
-                    ],
-                ],
-                'may_terminate' => true,
-            ],
             'site' => [
                 'child_routes' => [
                     'neatline' => [
-                        'type' => 'Literal',
+                        'type' => 'Segment',
                         'options' => [
-                            'route' => '/neatline',
+                            'route' => '/neatline[/:spa_route[/:spa_subroute[/:spa_subroute_1[/:spa_subroute_2]]]]',
+                            'constraints' => [
+                                'spa_route' => 'show|add',
+                            ],
                             'defaults' => [
                                 '__NAMESPACE__' => 'Neatline\Controller',
                                 'controller' => 'index',
@@ -85,6 +76,20 @@ return [
                             ],
                         ],
                         'may_terminate' => true,
+                        'child_routes' => [
+                            'full' => [
+                                'type' => 'Segment',
+                                'options' => [
+                                    'route' => '/full[/:spa_route[/:spa_subroute[/:spa_subroute_1[/:spa_subroute_2]]]]',
+                                    'constraints' => [
+                                        'spa_route' => 'show|add',
+                                    ],
+                                    'defaults' => [
+                                        'action' => 'full',
+                                    ],
+                                ],
+                            ],
+                        ],
                     ],
                 ],
             ],

--- a/src/Api/Adapter/RecordAdapter.php
+++ b/src/Api/Adapter/RecordAdapter.php
@@ -61,13 +61,11 @@ class RecordAdapter extends AbstractEntityAdapter
         if (isset($data['o:coverage'])) {
             $is_coverage = true;
             if (isset($data['o:coverage']['features'])) {
-                // $coverage = new Point($data['o:coverage']['coordinates'][0],
-                //                       $data['o:coverage']['coordinates'][1]);
                 $coverage = new GeometryCollection($data['o:coverage']['features']);
             }
         }
         if ($coverage === null) {
-            $coverage = new GeometryCollection(array());
+            $coverage = new GeometryCollection(array(array('type' => 'Feature', 'geometry' => array('type' => 'Point', 'coordinates' => array(0, 0)))));
         }
         $entity->setCoverage($coverage);
 

--- a/src/Api/Representation/ExhibitRepresentation.php
+++ b/src/Api/Representation/ExhibitRepresentation.php
@@ -56,7 +56,7 @@ class ExhibitRepresentation extends AbstractEntityRepresentation
             'o:slug' => $this->slug(),
             'o:narrative' => $this->narrative(),
             'o:spatial_querying' => $this->spatialQuerying(),
-            'o:public' => $this->public(),
+            'o:public' => $this->isPublic(),
             'o:styles' => $this->styles(),
             'o:map_focus' => $this->mapFocus(),
             'o:map_zoom' => $this->mapZoom(),
@@ -182,7 +182,7 @@ class ExhibitRepresentation extends AbstractEntityRepresentation
     	return $this->resource->getSpatialQuerying();
     }
 
-    public function public()
+    public function isPublic()
     {
     	return $this->resource->getPublic();
     }

--- a/src/Controller/IndexController.php
+++ b/src/Controller/IndexController.php
@@ -11,9 +11,13 @@ class IndexController extends AbstractActionController
 
     protected $serviceLocator;
 
-    public function indexAction()
+    protected function neatlineIndex($full = false)
     {
         $view = new ViewModel();
+        if ($full) {
+            $view->setTerminal(true);
+        }
+        $view->site_slug = $this->getEvent()->getRouteMatch()->getParam('site-slug');
         $asset_manifest = file_get_contents('modules/Neatline/asset/neatline/build/asset-manifest.json');
         $view->asset_manifest = json_decode($asset_manifest, true);
 
@@ -40,6 +44,16 @@ class IndexController extends AbstractActionController
         }
 
         return $view;
+    }
+
+    public function indexAction()
+    {
+        return $this->neatlineIndex(false);
+    }
+
+    public function fullAction()
+    {
+        return $this->neatlineIndex(true);
     }
 
     public function setServiceLocator($serviceLocator)

--- a/src/Entity/NeatlineExhibit.php
+++ b/src/Entity/NeatlineExhibit.php
@@ -224,12 +224,12 @@ class NeatlineExhibit extends AbstractEntity
 
     public function setSpatialLayers($spatial_layers)
     {
-        $this->spatial_layers = $spatial_layers;
+        $this->spatial_layers = implode(",", $spatial_layers);
     }
 
     public function getSpatialLayers()
     {
-        return $this->spatial_layers;
+        return array_filter(explode(",", $this->spatial_layers));
     }
 
     public function setSpatialLayer($spatial_layer)
@@ -352,9 +352,9 @@ class NeatlineExhibit extends AbstractEntity
         return (bool) $this->spatial_querying;
     }
 
-    public function setPublic($public)
+    public function setPublic($isPublic)
     {
-        $this->public = (bool) $public;
+        $this->public = (bool) $isPublic;
     }
 
     public function getPublic()

--- a/view/neatline/index/full.phtml
+++ b/view/neatline/index/full.phtml
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <link rel="stylesheet" href="<?php echo $this->assetUrl('neatline/build/' . $this->asset_manifest['main.css'], 'Neatline'); ?>" media="screen">
+  <link rel="stylesheet" href="/application/asset/css/style.css" media="screen">
+  <link rel="stylesheet" href="/application/asset/css/iconfonts.css" media="screen">
+</head>
+<body>
+<div id="root"></div>
+<script>
+    window.jwt = <?php echo !$this->jwt ? 'null' : '\'' . $this->jwt . '\'' ?>;
+    window.baseRoute = '/s/<?php echo $this->site_slug ?>/neatline/full';
+</script>
+<?php
+echo $this->inlineScript()
+    ->prependFile($this->assetUrl('neatline/build/' . $this->asset_manifest['main.js'], 'Neatline'));
+?>
+</body>
+</html>

--- a/view/neatline/index/index.phtml
+++ b/view/neatline/index/index.phtml
@@ -4,6 +4,7 @@ $this->headLink()->appendStylesheet($this->assetUrl('neatline/build/'. $this->as
 <div id="root"></div>
 <script>
     window.jwt = <?php echo !$this->jwt ? 'null' : '\'' . $this->jwt . '\'' ?>;
+    window.baseRoute = '/s/<?php echo $this->site_slug ?>/neatline';
 </script>
 <?php
 echo $this->inlineScript()


### PR DESCRIPTION
### What does this PR do?
- adds full-window view mode, which can be used by specifying /neatline/full in the URL
- makes exhibit field spatial_layers act as an array
- accommodates dynamic routes in the frontend app
- sets a 'baseRoute' window variable for the frontend app to use in generating its routes
- satisfies a not null constraint with default coverage value for records

### What issues does it address?
- Addresses #4 

### How to test
- At various points while testing functionality in the frontend application (i.e. in this PR's companion at https://github.com/performant-software/neatline-3/pull/20), try refreshing the browser window and confirming that the application reappears with the same view it was in pre-refresh.
- In addition to refreshing, switch between the full-window and Omeka-wrapped view modes by changing the /neatline to /neatline/full and back in the URL.