### PR TITLE
WIP: Reflect exhibit ownership in Neatline API results

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
+
 [submodule "asset/neatline"]
 	path = asset/neatline
-	url = https://github.com/performant-software/neatline-3.git
-	branch = master
+	url = git@github.com:scholarslab/neatline-3.git

--- a/.gitmodules-old
+++ b/.gitmodules-old
@@ -1,0 +1,3 @@
+[submodule "asset/neatline"]
+	path = asset/neatline
+	url = https://github.com/performant-software/neatline-3.git

--- a/.gitmodules-old
+++ b/.gitmodules-old
@@ -1,3 +1,0 @@
-[submodule "asset/neatline"]
-	path = asset/neatline
-	url = https://github.com/performant-software/neatline-3.git


### PR DESCRIPTION
### *TODO: after merge of #51, rebase this branch on master* ###

### What does this PR do?
- Adds logic to the API's exhibits filter to include non-public exhibits if they are owned by the authenticated user.
- Scopes exhibit creation to users with permission level of Editor or higher in the Omeka instance; scopes update and deletion according to ownership of the exhibit.

### What issues does it address?
- Closes #28 

### How to test
- Create multiple user accounts across various Omeka permission levels: one global admin, one editor, one below editor (e.g. reviewer)
- The global admin account, when signed in, should be able to see and edit all exhibits
- The editor account, when signed in, should be able to create new exhibits, see all public exhibits, and see + edit any exhibits that they created
- The reviewer account should be able to see only public exhibits and should not be able to edit exhibits (note: permissions are not reflected yet in the front end yet, so "not able to edit" for now means receives a rejection to the API request)