### PR TITLE
add Neatline navigation and enable full-window links

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'is_dev_mode' => false,
+    'is_dev_mode' => true,
     'controllers' => [
         'factories' => [
             'Neatline\Controller\Index' => 'Neatline\Service\Controller\IndexControllerFactory',
@@ -71,6 +71,22 @@ return [
                     ],
                 ],
             ],
+        ],
+    ],
+    'navigation' => [
+        'site' => [
+            [
+                'label' => 'Neatline',
+                'class' => 'neatline',
+                'route' => 'site/neatline',
+                'action' => 'index',
+                'useRouteMatch' => true,
+            ],
+        ],
+    ],
+    'navigation_links' => [
+        'invokables' => [
+            'neatline' => Neatline\Site\Navigation\Link\Neatline::class,
         ],
     ],
 ];

--- a/config/module.ini
+++ b/config/module.ini
@@ -7,7 +7,7 @@ module_link             = 'https://github.com/scholarslab/neatline-omeka-s'
 support_link            = 'https://forum.omeka.org/c/omeka-s/modules'
 license                 = 'Apache License, Version 2.0'
 omeka_version_constraint= '>=1.2.0'
-version                 = '0.1.0'
+version                 = '0.2.0'
 per_page                = '50'
 wms_mime                = 'image/png'
-configurable            = true
+configurable            = false

--- a/src/Site/Navigation/Link/Neatline.php
+++ b/src/Site/Navigation/Link/Neatline.php
@@ -1,0 +1,47 @@
+<?php
+namespace Neatline\Site\Navigation\Link;
+
+use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Stdlib\ErrorStore;
+use Omeka\Site\Navigation\Link\LinkInterface;
+
+class Neatline implements LinkInterface
+{
+    public function getName()
+    {
+        return 'Neatline';
+    }
+
+    public function getFormTemplate()
+    {
+        return 'common/navigation-link-form/neatline';
+    }
+
+    public function isValid(array $data, ErrorStore $errorStore)
+    {
+        return true;
+    }
+
+    public function getLabel(array $data, SiteRepresentation $site)
+    {
+        return isset($data['label']) && '' !== trim($data['label'])
+            ? $data['label'] : null;
+    }
+
+    public function toZend(array $data, SiteRepresentation $site)
+    {
+        return [
+            'route' => 'site/neatline',
+            'params' => [
+                'site-slug' => $site->slug(),
+            ],
+        ];
+    }
+
+    public function toJstree(array $data, SiteRepresentation $site)
+    {
+        return [
+            'label' => $data['label'],
+        ];
+    }
+}

--- a/view/common/navigation-link-form/neatline.phtml
+++ b/view/common/navigation-link-form/neatline.phtml
@@ -1,0 +1,7 @@
+<?php
+$translate = $this->plugin('translate');
+$escape = $this->plugin('escapeHtml');
+$label = isset($data['label']) && '' !== trim($data['label']) ? $data['label'] : null;
+?>
+<label><?php echo $translate('Type'); ?> <input type="text" value="<?php echo $escape($translate($link->getName())); ?>" disabled></label>
+<label><?php echo $translate('Label'); ?> <input type="text" data-name="label" value="<?php echo $escape($label); ?>"></label>

--- a/view/neatline/index/full.phtml
+++ b/view/neatline/index/full.phtml
@@ -9,6 +9,8 @@
 <div id="root"></div>
 <script>
     window.jwt = <?php echo !$this->jwt ? 'null' : '\'' . $this->jwt . '\'' ?>;
+    window.containerFullMode = true;
+    window.containerReturnBaseRoute = '/s/<?php echo $this->site_slug ?>/neatline';
     window.baseRoute = '/s/<?php echo $this->site_slug ?>/neatline/full';
 </script>
 <?php

--- a/view/neatline/index/index.phtml
+++ b/view/neatline/index/index.phtml
@@ -5,6 +5,8 @@ $this->headLink()->appendStylesheet($this->assetUrl('neatline/build/'. $this->as
 <div id="root"></div>
 <script>
     window.jwt = <?php echo !$this->jwt ? 'null' : '\'' . $this->jwt . '\'' ?>;
+    window.containerFullMode = false;
+    window.containerFullModeBaseRoute = '/s/<?php echo $this->site_slug ?>/neatline/full';
     window.baseRoute = '/s/<?php echo $this->site_slug ?>/neatline';
 </script>
 <?php


### PR DESCRIPTION
### What does this PR do?
- Adds a Neatline link to the admin dashboard's Site submenu
- Defines a Neatline type for Site navigation links, and
    - Adds an instance of this link type for any newly created Site
    - During module installation, adds this link to all existing Sites
    - During module uninstall, removes all instances of this link type from Sites
- Adds a `window.containerFullMode` flag and accompanying base route information to the container views so that the SPA can link between full-window and contained view modes

### What issues does it address?
- Closes #60 
- Closes #66 

### How to test
- As an admin user in an Omeka S instance, after installing/upgrading the Neatline module and having created at least one Site, you should be able to enter the admin dashboard, select a Site within the list, and then see a link for Neatline at the bottom of the nested submenu that appears in the left-hand menu for the site. Clicking this link should bring you to the site's Neatline view, which should show editor functionality as you are logged in with admin permissions.
- Upon installing Neatline in an Omeka S instance with one or more existing Sites, open a Site's public view; a "Neatline" link should appear in the navigation list alongside the default "Browse"; clicking this should bring you to the same Neatline view as from the admin dashboard link.
- Likewise, newly created Sites should have the Neatline link in their navigation.
- You should be able to apply a custom label to the Neatline navigation link in Admin -> Site -> Navigation. You should also see a "Neatline" entry on the right among the link types that can be added.
- After uninstalling Neatline, its navigation links should no longer appear for any Site.
- (Toggling between full-window and contained view modes is being enabled in the SPA, so testing notes will be in that repository.)