### PR TITLE
NL #90 - Routing

### DIFF
--- a/view/neatline/index/full.phtml
+++ b/view/neatline/index/full.phtml
@@ -1,11 +1,21 @@
+<?php
+$translate = $this->plugin('translate');
+$this->headMeta()->setCharset('utf-8');
+$this->headMeta()->appendName('viewport', 'width=device-width, initial-scale=1');
+$this->headTitle($this->setting('installation_title', 'Omeka S'))->setSeparator(' · ');
+$this->headLink()->prependStylesheet('//fonts.googleapis.com/css?family=Source+Code+Pro|Lato:400,400italic,700,700italic');
+$this->headLink()->appendStylesheet($this->assetUrl('neatline/build/'. $this->asset_manifest['main.css'], 'Neatline'));
+$this->headLink()->appendStylesheet($this->assetUrl('css/iconfonts.css', 'Omeka'));
+$this->headLink()->appendStylesheet($this->assetUrl('css/style.css', 'Omeka'));
+?>
+
 <html>
 <head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link href="//fonts.googleapis.com/css?family=Source+Code+Pro|Lato:400,400italic,700,700italic" media="screen" rel="stylesheet" type="text/css">
-  <link rel="stylesheet" href="<?php echo $this->assetUrl('neatline/build/' . $this->asset_manifest['main.css'], 'Neatline'); ?>" media="screen">
-  <link rel="stylesheet" href="/application/asset/css/style.css" media="screen">
-  <link rel="stylesheet" href="/application/asset/css/iconfonts.css" media="screen">
+  <?php echo $this->headMeta(); ?>
+  <?php echo $this->headTitle(); ?>
+  <?php echo $this->headLink(); ?>
+  <?php echo $this->headStyle(); ?>
+  <?php echo $this->headScript(); ?>
 </head>
 <style>
   body {
@@ -16,9 +26,18 @@
 <div id="root"></div>
 <script>
     window.jwt = <?php echo !$this->jwt ? 'null' : '\'' . $this->jwt . '\'' ?>;
+
+    let baseUrl = <?php echo '\'' . $_SERVER['REQUEST_URI'] . '\'' ?>;
+    baseUrl = baseUrl.replace(/(.+)\/admin\/neatline(\/.+)?/gi, '$1');
+
+    if (baseUrl.startsWith('/admin')) {
+      baseUrl = '';
+    }
+
     window.containerFullMode = true;
-    window.containerReturnBaseRoute = '/admin/neatline';
-    window.baseRoute = '/admin/neatline/full';
+    window.containerReturnBaseRoute = `${baseUrl}/admin/neatline`;
+    window.baseRoute = `${baseUrl}/admin/neatline/full`;
+    window.baseUrl = baseUrl;
 </script>
 <?php
 echo $this->inlineScript()

--- a/view/neatline/index/index.phtml
+++ b/view/neatline/index/index.phtml
@@ -6,9 +6,17 @@ $this->headLink()->appendStylesheet($this->assetUrl('neatline/build/'. $this->as
     const jwt = <?php echo !$this->jwt ? 'null' : '\'' . $this->jwt . '\'' ?>;
     sessionStorage.setItem('token', jwt);
 
+    let baseUrl = <?php echo '\'' . $_SERVER['REQUEST_URI'] . '\'' ?>;
+    baseUrl = baseUrl.replace(/(.+)\/admin\/neatline(\/.+)?/gi, '$1');
+
+    if (baseUrl.startsWith('/admin')) {
+      baseUrl = '';
+    }
+
     window.containerFullMode = false;
-    window.containerFullModeBaseRoute = '/admin/neatline/full';
-    window.baseRoute = '/admin/neatline';
+    window.containerFullModeBaseRoute = `${baseUrl}/admin/neatline/full`;
+    window.baseRoute = `${baseUrl}/admin/neatline`;
+    window.baseUrl = baseUrl;
 </script>
 <?php
 echo $this->inlineScript()


### PR DESCRIPTION
This pull request updates the Neatline plugin to run when Omeka S is mounted at a subdirectory (i.e. `http://localhost:8080/omeka-s`). We add a new attribute to the `window` object for `baseUrl`, which will be determined from the request URI.

This pull request also updates the full mode to append the correct style sheets to the `<head>` object.