### PR TITLE
NL #83 - Page blocks

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -46,6 +46,13 @@ class Module extends AbstractModule
              'Neatline\Entity\NeatlineRecord'],
             'view-all'
         );
+
+        $acl->allow(
+            null,
+            ['Neatline\Entity\NeatlineExhibit',
+             'Neatline\Entity\NeatlineRecord'],
+            'read'
+        );
     }
 
     public function install(ServiceLocatorInterface $serviceLocator)

--- a/src/Site/BlockLayout/NeatlineExhibit.php
+++ b/src/Site/BlockLayout/NeatlineExhibit.php
@@ -41,19 +41,11 @@ class NeatlineExhibit extends AbstractBlockLayout
 
     }
 
-    public function prepareRender(PhpRenderer $view)
-    {
-        // $view->headLink()->appendStylesheet($view->assetUrl('neatline/build/'. $view->asset_manifest['main.css'], 'Neatline'));
-        // $view->headScript()->appendFile($view->assetUrl('neatline/build/' . $view->asset_manifest['main.js'], 'Neatline'));
-
-        // $view->inlineScript()->prependFile($view->assetUrl('neatline/build/' . $view->asset_manifest['main.js'], 'Neatline'));
-    }
-
     public function render(PhpRenderer $view, SitePageBlockRepresentation $block)
     {
-
         return $view->partial('common/block-layout/neatline-exhibit', [
-            'block' => $block,
+          'block' => $block,
+          'exhibit_id' => $block->dataValue('neatline_exhibit')
         ]);
     }
 }

--- a/view/common/block-layout/neatline-exhibit.phtml
+++ b/view/common/block-layout/neatline-exhibit.phtml
@@ -1,6 +1,1 @@
-<div class="neatline-exhibit-block">
-    <div class="neatline-exhibit-title">
-        <h2>Exhibit Title</h2>
-    </div>
-    <div class="neatline-exhibit-map" style="height: 500px; position: relative; background-color: #ddd;"></div>
-</div>
+<div name="neatline-public-exhibit" data-exhibit-id="<?php echo $this->exhibit_id ?>"></div>

--- a/view/omeka/site/page/show.phtml
+++ b/view/omeka/site/page/show.phtml
@@ -1,0 +1,42 @@
+<?php
+$manifest = file_get_contents('modules/Neatline/asset/neatline/build/asset-manifest.json');
+$asset_manifest = json_decode($manifest, true);
+
+$this->headLink()->appendStylesheet($this->assetUrl('css/page-blocks.css', 'Omeka'));
+$this->headLink()->appendStylesheet($this->assetUrl('neatline/build/'. $asset_manifest['main.css'], 'Neatline'));
+$this->htmlElement('body')->appendAttribute('class', 'page');
+$this->pageTitle($page->title(), 2);
+$showPagePagination = $this->siteSetting('show_page_pagination', true);
+?>
+
+<?php
+$nav = $site->publicNav();
+$container = $nav->getContainer();
+$activePage = $nav->findActive($container);
+if ($activePage):
+?>
+    <?php if ($activePage['depth'] !== 0): ?>
+    <nav class="breadcrumbs"><?php echo $nav->breadcrumbs(); ?></nav>
+    <?php endif; ?>
+<?php endif; ?>
+
+<?php if ($activePage): ?>
+    <?php if ($this->displayNavigation && $activePage['page']->hasPages()): ?>
+    <nav class="sub-menu"><?php echo $nav->menu()->renderSubMenu(); ?></nav>
+    <?php endif; ?>
+<?php endif; ?>
+
+<?php $this->trigger('view.show.before'); ?>
+<div class="blocks">
+    <?php echo $this->content; ?>
+</div>
+<script>
+  window.baseRoute = '/s';
+</script>
+<?php
+echo $this->inlineScript()->prependFile($this->assetUrl('neatline/build/' . $asset_manifest['main.js'], 'Neatline'));
+?>
+<?php $this->trigger('view.show.after'); ?>
+<?php if ($showPagePagination): ?>
+<?php echo $this->sitePagePagination(); ?>
+<?php endif; ?>


### PR DESCRIPTION
This pull request updates the Neatline plugin to pass the exhibit ID to the Neatline page block. It also updates the page block view to contain a `div` with a `name` attribute to be bootstrapped by React.

![Screen Shot 2021-03-03 at 9 36 29 AM](https://user-images.githubusercontent.com/20641961/109832049-029a8700-7c0e-11eb-856a-f68fae745be7.png)
